### PR TITLE
CDRIVER-3356: Reduce fragility of Nuget packaging for C# binding

### DIFF
--- a/bindings/cs/MongoDB.Libmongocrypt/MongoDB.Libmongocrypt.targets
+++ b/bindings/cs/MongoDB.Libmongocrypt/MongoDB.Libmongocrypt.targets
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
-    <ItemGroup Condition="'$(OS)' == 'Windows_NT'">
+    <ItemGroup Condition="$([MSBuild]::IsOsPlatform('Windows'))">
         <Content Include="$(MSBuildThisFileDirectory)../x64/native/windows/mongocrypt.dll">
             <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
             <Link>mongocrypt.dll</Link>


### PR DESCRIPTION
 https://evergreen.mongodb.com/version/5d6ed9ee3e8e8658d56fa5b2
https://jira.mongodb.org/browse/CDRIVER-3356

The FLE branch no longer sees mongocrypt.dll loading errors:
https://evergreen.mongodb.com/version/5d6ed6a45623432910599864