### PR TITLE
MONGOCRYPT-195 Remove pdb from C# binding

### DIFF
--- a/bindings/cs/MongoDB.Libmongocrypt/MongoDB.Libmongocrypt.csproj
+++ b/bindings/cs/MongoDB.Libmongocrypt/MongoDB.Libmongocrypt.csproj
@@ -69,13 +69,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Content Include="$(LibMongoCryptBinaries)/mongocrypt.pdb">
-      <Pack>true</Pack>
-      <PackagePath>x64/native/windows</PackagePath>
-    </Content>
-  </ItemGroup>
-
-  <ItemGroup>
     <Content Include="License.txt">
       <Pack>true</Pack>
       <PackagePath>$(PackageLicenseFile)</PackagePath>

--- a/bindings/cs/MongoDB.Libmongocrypt/MongoDB.Libmongocrypt.targets
+++ b/bindings/cs/MongoDB.Libmongocrypt/MongoDB.Libmongocrypt.targets
@@ -6,9 +6,5 @@
             <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
             <Link>mongocrypt.dll</Link>
         </Content>
-        <Content Include="$(MSBuildThisFileDirectory)../x64/native/windows/mongocrypt.pdb">
-            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-            <Link>mongocrypt.pdb</Link>
-        </Content>
     </ItemGroup>
 </Project>


### PR DESCRIPTION
https://jira.mongodb.org/browse/MONGOCRYPT-195
http://evergreen.mongodb.com/patches/project/libmongocrypt
EG is green for net452 and tests pass locally for netcore. 
I've also tested that the package can be consumed without an error